### PR TITLE
Ignore if dataset doesn't exist and clean its reference from the cache

### DIFF
--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -352,10 +352,20 @@ func setQuota(name string, quota string) error {
 
 // Remove deletes the dataset, filesystem and the cache for the given id.
 func (d *Driver) Remove(id string) error {
+	var cleanCache = d.Exists(id)
 	name := d.zfsPath(id)
 	dataset := zfs.Dataset{Name: name}
 	err := dataset.Destroy(zfs.DestroyRecursive)
-	if err == nil {
+	if err != nil {
+		cleanCache = false
+		if zfsError, ok := err.(*zfs.Error); ok {
+			if strings.HasSuffix(zfsError.Stderr, "dataset does not exist\n") {
+				cleanCache = true
+				err = nil
+			}
+		}
+	}
+	if cleanCache {
 		d.Lock()
 		delete(d.filesystemsCache, name)
 		d.Unlock()


### PR DESCRIPTION
# Backgorund
docker on zfs driver is unable to maintain its cached state for deleted datasets often that result in exceptions while removing those datasets that are already non-existant (i.e. probably deleted earlier without proper clearing-out of the cached state on docker side). When this happens, ix apps are stuck in terminating state until someone intervene manually and force CRI to not wait for actual removal of the container and move-on to creating new container but terminating one will still remain stuck in the background.

This PR provides us with a way around such that we just ignore such a dataset and also clear it from cache – This will not to have any drawback as docker was already doing the same with a difference that it errors out if dataset does not exist.