### PR TITLE
Fix zfs go to handle spaces properly

### DIFF
--- a/vendor/github.com/mistifyio/go-zfs/utils.go
+++ b/vendor/github.com/mistifyio/go-zfs/utils.go
@@ -65,7 +65,11 @@ func (c *command) Run(arg ...string) ([][]string, error) {
 	output := make([][]string, len(lines))
 
 	for i, l := range lines {
-		output[i] = strings.Fields(l)
+		if len(arg) > 0 && arg[0] == "list" {
+			output[i] = strings.Split(l, "\t")
+		} else {
+			output[i] = strings.Fields(l)
+		}
 	}
 
 	return output, nil


### PR DESCRIPTION
## Problem

Docker was not handling the scenario nicely where the root dataset had spaces in it's name.

## Investigation

After looking at source, it was found that the responsible bit for the error was `go-zfs` which was not parsing correctly the output it received from `zfs list`. It was splitting on whitespace instead of `\t` which resulted in more columns then desired and various commands failing because of this issue.