### PR TITLE
Fix docker not building

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: "${ROOTLESSKIT_VERSION:=v0.14.4}"
+: "${ROOTLESSKIT_VERSION:=v1.0.1}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
## Problem

Docker build was failing frequently with the following errors
```
go: downloading github.com/rootless-containers/rootlesskit v0.14.4
go install: github.com/rootless-containers/rootlesskit/cmd/rootlesskit@v0.14.4: github.com/rootless-containers/rootlesskit@v0.14.4 requires
	github.com/stretchr/testify@v1.7.0 requires
	gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c: unrecognized import path "gopkg.in/yaml.v3": reading https://gopkg.in/yaml.v3?go-get=1: 502 Bad Gateway
	server response: Cannot obtain refs from GitHub: cannot talk to GitHub: Get https://github.com/go-yaml/yaml.git/info/refs?service=git-upload-pack: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

## Solution

It seemed that we had issues with the specific version of the rootless kit which docker builds and after much back and forth, I saw the version which we were building was quite outdated and upstream 20.10 docker had not deviated away from it yet but bumping this resolved the go-yaml issue which we were seeing likely due to newer set of dependencies being pulled in. From the testing done, it does not seem there is any regression from bumping up the version of the rootlesskit and it resolved the failing package build 100% of the time in my testing.