### PR TITLE
White list host paths being consumed by Rsync Module

### DIFF
--- a/volume/mounts/validate.go
+++ b/volume/mounts/validate.go
@@ -99,6 +99,7 @@ func getAttachments(path string) []string {
 		"Chart Releases",
 		"Rsync Task",
 		"Snapshot Task",
+		"Rsync Module",
 	}
 	if err == nil {
 		attachmentsResults := attachments.([]interface{})


### PR DESCRIPTION
## Context

It was requested that we whitelist host paths being consumed by `Rsync Module` attachments similar to how we have done for Rsync/Snapshot tasks.