### PR TITLE
White list host paths being consumed by CloudSync Task

### DIFF
--- a/volume/mounts/validate.go
+++ b/volume/mounts/validate.go
@@ -100,6 +100,7 @@ func getAttachments(path string) []string {
 		"Rsync Task",
 		"Snapshot Task",
 		"Rsync Module",
+		"CloudSync Task",
 	}
 	if err == nil {
 		attachmentsResults := attachments.([]interface{})


### PR DESCRIPTION
## Context

It was requested that we whitelist host paths being consumed by `CloudSync Task` attachments similar to how we have done for Rsync/Snapshot tasks.