### PR TITLE
Allow docker to run only when k3s pool is set

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -758,7 +758,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	err = middleware.InitConfig()
 	if err != nil {
 		logrus.Errorf("Failed to initialize middleware configuration %s", err)
+	} else if !middleware.IsPoolConfigured() {
+		return nil, fmt.Errorf("Kubernetes Pool is not initialized")
 	}
+
 	setDefaultMtu(config)
 
 	registryService, err := registry.NewService(config.ServiceOptions)

--- a/middleware/configs.go
+++ b/middleware/configs.go
@@ -95,3 +95,14 @@ func GetIgnorePaths() []string {
 func GetRootDataset() string {
 	return clientConfig.appsDataset
 }
+
+func IsPoolConfigured() bool {
+	resp, err := Call("kubernetes.config")
+	if err == nil {
+		pool_name := resp.(map[string]interface{})["pool"]
+		if pool_name != nil {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Context

Do not allow starting docker if kubernetes pool is not configured to prevent users from consuming the service directly as that will result in docker creating it's state in boot-pool which is not desirable.