### PR TITLE
Fix go middleware client string martial

### DIFF
--- a/middleware/call.go
+++ b/middleware/call.go
@@ -32,6 +32,7 @@ func Call(method string, params ...interface{}) (interface{}, error) {
 
 	err = json.Unmarshal([]byte(out), &sanitizedResult)
 	if err != nil {
+		sanitizedResult = string(out)
 		logrus.Errorf("Failed to unmarshall middleware response for %s method with response %s: %s", method, out, err)
 	}
 

--- a/volume/mounts/validate.go
+++ b/volume/mounts/validate.go
@@ -29,8 +29,8 @@ func errMissingField(name string) error {
 }
 
 func hostPathValidation(path string) error {
-	validationErr, err := middleware.Call("chart.release.validate_host_source_path", path)
-	if err == nil && validationErr != nil {
+	validationErr, _ := middleware.Call("chart.release.validate_host_source_path", path)
+	if validationErr != nil {
 		return errors.Errorf(validationErr.(string))
 	}
 	return nil


### PR DESCRIPTION
## Context

Errors returned by middlewared cannot be unmartialed e.g
```
ERRO[0000] Failed to unmarshall middleware response for chart.release.validate_host_source_path method with response 'rpoot' 'path' not allowed to be mounted
: invalid character '\'' looking for beginning of value
```